### PR TITLE
feat: add organization_enabled_features for centralized root access

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -1,11 +1,29 @@
 locals {
-  enabled = module.this.enabled
+  enabled                       = module.this.enabled
+  organization_features_enabled = length(var.organization_enabled_features) > 0
+
+  # Ensure iam.amazonaws.com is in service access principals when IAM features are enabled
+  iam_service_principal = local.organization_features_enabled ? ["iam.amazonaws.com"] : []
+  aws_service_access_principals = distinct(concat(
+    var.aws_service_access_principals,
+    local.iam_service_principal
+  ))
 }
 
 resource "aws_organizations_organization" "this" {
   count = local.enabled ? 1 : 0
 
-  aws_service_access_principals = var.aws_service_access_principals
+  aws_service_access_principals = local.aws_service_access_principals
   enabled_policy_types          = var.enabled_policy_types
   feature_set                   = var.feature_set
+}
+
+# Centralized root access features
+# See: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-enable-root-access.html
+resource "aws_iam_organizations_features" "this" {
+  count = local.enabled && local.organization_features_enabled ? 1 : 0
+
+  enabled_features = var.organization_enabled_features
+
+  depends_on = [aws_organizations_organization.this]
 }

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -37,3 +37,8 @@ output "roots" {
   value       = try(aws_organizations_organization.this[0].roots, [])
   description = "List of organization roots"
 }
+
+output "organization_enabled_features" {
+  value       = try(aws_iam_organizations_features.this[0].enabled_features, [])
+  description = "List of enabled IAM organization features"
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -25,3 +25,9 @@ variable "feature_set" {
     error_message = "feature_set must be one of: ALL, CONSOLIDATED_BILLING"
   }
 }
+
+variable "organization_enabled_features" {
+  type        = list(string)
+  description = "List of IAM features to enable. Valid values are 'RootCredentialsManagement' and 'RootSessions'. Set to empty list to disable."
+  default     = []
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -30,4 +30,12 @@ variable "organization_enabled_features" {
   type        = list(string)
   description = "List of IAM features to enable. Valid values are 'RootCredentialsManagement' and 'RootSessions'. Set to empty list to disable."
   default     = []
+
+  validation {
+    condition = alltrue([
+      for feature in var.organization_enabled_features :
+      contains(["RootCredentialsManagement", "RootSessions"], feature)
+    ])
+    error_message = "Valid values for organization_enabled_features are 'RootCredentialsManagement' and 'RootSessions'."
+  }
 }


### PR DESCRIPTION
## What
Add `organization_enabled_features` variable and `aws_iam_organizations_features` resource to enable centralized root access.

## Why
AWS Centralized Root Access allows management account administrators to assume root in member accounts using short-lived STS credentials. This feature requires enabling `RootCredentialsManagement` and `RootSessions` at the organization level.

## References
- [AWS Centralized Root Access Documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-enable-root-access.html)
- Terraform resource: `aws_iam_organizations_features`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable IAM organization features (RootCredentialsManagement, RootSessions) for your organization.
  * New configuration option to specify which IAM organization features to enable, with validation of allowed values.
  * Conditional activation of organization IAM features only when enabled in configuration.
  * New output that exposes the list of currently enabled organization features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->