### PR TITLE
chore: migrate Renovate config preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## Summary
- migrate Renovate from deprecated `config:base` to `config:recommended`
- keep the existing `prConcurrentLimit: 5` setting unchanged

## Verification
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

I did not run `atmos test run` because this change only touches Renovate configuration and the repo guidance says the Terratest/Atmos suite deploys AWS resources and may incur cost.